### PR TITLE
Fix decompiler issue with templates/milo/mat.bt

### DIFF
--- a/templates/milo/mat.bt
+++ b/templates/milo/mat.bt
@@ -324,10 +324,10 @@ typedef struct (SystemInfo& info, Bool super)
         Bool fade_out;     // Is the Mat affected its Environment's fade_out?
         
         // TODO: Figure out this condition
-        /*if (&DAT_ffffffd4 + version < &DAT_00000002)
+        if (version < 46)
         {
             Bool ignored_bool_4;
-        }*/
+        }
 
         if (version > 46)
         {
@@ -364,7 +364,7 @@ typedef struct (SystemInfo& info, Bool super)
     {
         if (version < 53)
         {
-            Bool ignored_bool_4;
+            Bool ignored_bool_5;
         }
         else
         {


### PR DESCRIPTION
Was scrolling through mat.bt, and I saw that Ghidra, in its infinite wisdom, got signed integers confused for memory addresses. This fixes that, using the logic of "it's getting the memory addresses of dat_ffffffd4 and dat_2, so it's using ffffffd4 (-44, evidently) and 2 to say "if -44 + version < 2", time to fix that", then using basic math to move the -44 to the other side, thus, pre-v46.

also a variable name conflict