### PR TITLE
Add support for ParticleSys, Sfx, UILabelDir

### DIFF
--- a/templates/milo/common.bt
+++ b/templates/milo/common.bt
@@ -225,7 +225,18 @@ typedef struct
     float g;
     float b;
     float a;
-} Color4<read=readColor4>;
+} Color4<read=readColor4, bgcolor=get_bgcolor4_color>;
+
+int get_bgcolor4_color(Color4& c)
+{
+    local int r = (int)(c.r * 255.0);
+    local int g = (int)(c.g * 255.0);
+    local int b = (int)(c.b * 255.0);
+    local int a = (int)(c.a * 255.0);
+
+    // BGR order
+    return (b << 16) | (g << 8) | r;
+}
 
 string readColor4(Color4& c)
 {

--- a/templates/milo/group_seq.bt
+++ b/templates/milo/group_seq.bt
@@ -1,0 +1,77 @@
+// A sequence which plays other sequences.  Abstract base class.
+// Super: Sequence
+// Ext: .cue
+// C++ Class: GroupSeq
+
+#ifndef IN_MILO_FILE
+    #ifndef STANDALONE_FILE
+        #define STANDALONE_FILE "GroupSeq"
+    #endif
+#endif
+
+#ifndef OBJECT_GROUP_SEQ
+#define OBJECT_GROUP_SEQ
+
+#include "common.bt"
+#include "draw.bt"
+
+typedef struct(SystemInfo& info, Bool super)
+{
+    int version; // 3 (RB3)
+
+    if(2 < version)
+    {
+        read_metadata(info, super);
+    }
+
+    float avg_vol;
+    float vol_spread;
+    float avg_transpose;
+    float transpose_spread;
+    float avg_pan;
+    float pan_spread;
+
+    if(1 < version)
+    {
+        Bool can_stop;
+    }
+} Sequence;
+
+typedef struct (SystemInfo& info, Bool super)
+{
+    int version; // 3 (RB3)
+
+    if(1 < version)
+    {
+        Sequence sequence(info, super);
+
+        // game technically has a version check here to do different stuff when reading these children, but this is just for internal logic (not how things are saved/loaded from the file)
+        int children_count;
+        NumString children[children_count]<optimize=false>;
+
+    }
+} GroupSeq;
+
+#ifdef STANDALONE_FILE
+
+if (STANDALONE_FILE == "GroupSeq")
+{
+    local int obj_version = guess_version();
+    local SystemInfo info;
+    info.version = 25;
+
+    if (IsBigEndian())
+    {
+        info.platform = X360;
+    }
+    else
+    {
+        info.platform = PS2;
+    }
+
+    GroupSeq group_seq(info, False);
+}
+
+#endif
+
+#endif

--- a/templates/milo/milo_file.bt
+++ b/templates/milo/milo_file.bt
@@ -18,8 +18,12 @@ struct MiloFile;
 #include "objects.bt"
 #include "p9_character.bt"
 #include "panel_dir.bt"
+#include "particle_sys.bt"
+#include "random_group_seq.bt"
 #include "rnd_dir.bt"
+#include "sfx.bt"
 #include "synth_dir.bt"
+#include "ui_label_dir.bt"
 #include "world_dir.bt"
 #include "world_instance.bt"
 
@@ -175,6 +179,12 @@ typedef struct (SystemInfo& info, string class_name, string name, Bool is_entry)
             PanelDir object(info, False, False, is_entry);
             is_dir = 1;
             break;
+        case "ParticleSys":
+            ParticleSys object(info, False);
+            break;
+        case "RandomGroupSeq":
+            RandomGroupSeq object(info, False);
+            break;
         case "RndDir":
             // Doesn't seem to ever write dir for gh2 milos
             RndDir object(info, False, False);
@@ -184,6 +194,9 @@ typedef struct (SystemInfo& info, string class_name, string name, Bool is_entry)
             {
                 should_read_milo = 1;
             }
+            break;
+        case "Sfx":
+            Sfx object(info, False);
             break;
         case "SynthDir":
             SynthDir object(info, False, False);
@@ -198,6 +211,10 @@ typedef struct (SystemInfo& info, string class_name, string name, Bool is_entry)
             break;
         case "Trans":
             Trans object(info, False);
+            break;
+        case "UILabelDir":
+            UILabelDir object(info, False, False);
+            is_dir = 1;
             break;
         case "WorldDir":
             WorldDir object(info, False, False);

--- a/templates/milo/particle_sys.bt
+++ b/templates/milo/particle_sys.bt
@@ -1,0 +1,194 @@
+// An animated clip of a skeleton playable in milo
+// Super: Anim
+// Ext: .part
+// C++ Class: RndParticleSys
+
+#ifndef IN_MILO_FILE
+    #ifndef STANDALONE_FILE
+        #define STANDALONE_FILE "ParticleSys"
+    #endif
+#endif
+
+#ifndef OBJECT_PARTICLE_SYS
+#define OBJECT_PARTICLE_SYS
+
+#include "common.bt"
+
+typedef struct (SystemInfo& info, Bool super)
+{
+    // 30 (GH2-360), 36 (RB1), 37 (RB2/TBRB/GDRB/RB3/DC1)
+    int version;
+    read_metadata(info, super);
+    read_metadata(info, super);
+
+    Anim anim(info, True);
+    Trans trans(info, True);
+    Draw draw(info, True);
+
+    Vector2 life;
+
+    if(35 < version)
+    {
+        float height_ratio;
+    }
+
+
+
+    Vector3 pos_low;
+    Vector3 pos_high;
+
+    Vector2 speed;
+    Vector2 pitch;
+    Vector2 yaw;
+    Vector2 emit_rate;
+
+    if(32 < version)
+    {
+        int max_bursts;
+        Vector2 burst_interval;
+        Vector2 burst_peak;
+        Vector2 burst_length;
+    }
+
+    Vector2 start_size;
+
+    if(15 < version)
+    {
+        Vector2 delta_size;
+    }
+
+    Color4 startColorLow;
+    Color4 startColorHigh;
+
+    Color4 endColorLow;
+    Color4 endColorHigh;
+
+    NumString bounce;
+
+    Vector3 force;
+
+    NumString material;
+
+    if(version < 18)
+    {
+        if(version < 13)
+        {
+            int unknown;
+        }
+    }
+    else
+    {
+        int unknown;
+        float grow_ratio;
+        float shrink_ratio;
+
+        float mid_color_ratio;
+
+        Color4 mid_color_low;
+        Color4 mid_color_high;
+    }
+
+    int max_particles;
+
+    if(2 < version)
+    {
+        if(version < 7)
+        {
+            int unknown;
+        }
+        else if (version < 13)
+        {
+            int unknown;
+        }
+    }
+
+    if(3 < version)
+    {
+        Vector2 bubble_period;
+        Vector2 bubble_size;
+        Bool bubble;
+    }
+
+    if(29 < version)
+    {
+        Bool rotate;
+
+        Vector2 rot_speed;
+        float rot_drag;
+        if(36 < version)
+        {
+            Bool rot_random_direction;
+        }
+
+        int drag;
+    }
+
+    if(31 < version)
+    {
+        Vector2 swing_arm_start;
+        Vector2 swing_arm_end;
+
+        Bool align_with_velocity;
+        Bool stretch_with_velocity;
+        Bool constant_area;
+
+        float stretch_scale;
+    }
+
+    if(33 < version)
+    {
+        Bool perspective_stretch;
+    }
+
+    float relative_motion;
+
+    if(26 < version)
+    {
+        NumString relative_parent;
+    }
+
+    if(18 < version)
+    {
+        NumString mesh;
+    }
+    
+    if(30 < version || version == 21)
+    {
+        int sub_samples;
+    }
+
+    if(!(version < 28))
+    {
+        Bool frame_drive;
+    }
+
+    if(!(version < 35))
+    {
+        Bool pause_offscreen;
+    }
+
+    if(!(version < 29))
+    {
+        Bool fast_forward;
+    }
+
+    if(!(version < 11))
+    {
+        Bool preserve_particles;
+    }
+} ParticleSys;
+
+#ifdef STANDALONE_FILE
+
+if (STANDALONE_FILE == "ParticleSys")
+{
+    local int obj_version = guess_version();
+    local SystemInfo info;
+    info.version = 28;
+
+    ParticleSys particle_sys(info, False);
+}
+
+#endif
+
+#endif

--- a/templates/milo/random_group_seq.bt
+++ b/templates/milo/random_group_seq.bt
@@ -1,0 +1,58 @@
+// Plays one or more of its child sequences, selected at random.
+// Super: GroupSeq
+// Ext: .cue
+// C++ Class: RandomGroupSeq
+
+#ifndef IN_MILO_FILE
+    #ifndef STANDALONE_FILE
+        #define STANDALONE_FILE "RandomGroupSeq"
+    #endif
+#endif
+
+#ifndef OBJECT_RANDOM_GROUP_SEQ
+#define OBJECT_RANDOM_GROUP_SEQ
+
+#include "common.bt"
+#include "group_seq.bt"
+#include "draw.bt"
+
+typedef struct (SystemInfo& info, Bool super)
+{
+    int version; // 2 (RB3)
+    if(version < 3)
+    {
+        GroupSeq group_sequence(info, super);
+        int num_simultaneous;
+
+        if(1 < version)
+        {
+            Bool allow_repeats;
+        }
+    }
+
+
+} RandomGroupSeq;
+
+#ifdef STANDALONE_FILE
+
+if (STANDALONE_FILE == "RandomGroupSeq")
+{
+    local int obj_version = guess_version();
+    local SystemInfo info;
+    info.version = 25;
+
+    if (IsBigEndian())
+    {
+        info.platform = X360;
+    }
+    else
+    {
+        info.platform = PS2;
+    }
+
+    RandomGroupSeq random_group_seq(info, False);
+}
+
+#endif
+
+#endif

--- a/templates/milo/sample_data.bt
+++ b/templates/milo/sample_data.bt
@@ -19,7 +19,7 @@ https://github.com/FFmpeg/FFmpeg/blob/master/libavcodec/wmaprodec.c
 
 typedef struct (SystemInfo& info)
 {
-    int version; // 11 (GH2 4-song/GH2/GH2 360/RB2), 13 (TBRB/GDRB)
+    int version; // 11 (GH2 4-song/GH2/GH2 360/RB2), 13 (TBRB/GDRB) 14 (RB3)
 
     // 1 = Uncompressed 16-bit PCM
     // 2 =  ??? (PS2)
@@ -32,9 +32,14 @@ typedef struct (SystemInfo& info)
     int sample_rate;  // PS2 usually 16kHz (Also observed: 22.05kHz), 360 usually 44.1kHz
     int samples_size;
 
-    Bool some_bool;
+    Bool read_samples; // game will only read samples if this is true, otherwise it will just act like sample byte array is empty
 
     if (samples_size > 0) byte samples[samples_size];
+
+    if(version >= 14)
+    {
+        int unk_int;
+    }
 } SampleData;
 
 

--- a/templates/milo/sfx.bt
+++ b/templates/milo/sfx.bt
@@ -80,7 +80,7 @@ typedef struct
 
 typedef struct (SystemInfo& info, Bool super)
 {
-    int version; // 9 (RB2/TBRB/GDRB), 12 (RB3)
+    int version; // 5 (GH2 360), 9 (RB1/RB2/TBRB/GDRB), 12 (RB3)
 
     if(version < 6)
     {
@@ -107,15 +107,20 @@ typedef struct (SystemInfo& info, Bool super)
     {
         NumString send_obj;
     }
+    
+    if(version < 8)
+    {
+        float unknown;
+    }
 
     if(8 < version)
     {
         FaderGroup fader_group;
     }
 
-    if(version > 0xb)
+    if(version > 11)
     {
-        float unk;
+        float unk_float;
         Bool unk_bool;
     }
 

--- a/templates/milo/sfx.bt
+++ b/templates/milo/sfx.bt
@@ -1,0 +1,147 @@
+// Basic sound effect object.  Plays several samples with a given volume, pan, transpose, and envelope settings.
+// Super: Sfx
+// Ext: .cue
+// C++ Class: Sfx
+
+#ifndef IN_MILO_FILE
+    #ifndef STANDALONE_FILE
+        #define STANDALONE_FILE "Sfx"
+    #endif
+#endif
+
+#ifndef OBJECT_SFX
+#define OBJECT_SFX
+
+#include "common.bt"
+#include "group_seq.bt"
+#include "draw.bt"
+
+typedef enum <int> {
+    kAttackLinear = 0,
+    kAttackExp = 1,
+} AttackMode;
+
+typedef enum <int> {
+    kSustainLinInc = 0,
+    kSustainLinDec = 2,
+    kSustainExpInc = 4,
+    kSustainExpDec = 6,
+} SustainMode;
+
+typedef enum <int> {
+    kReleaseLinear = 0,
+    kReleaseExp = 1,
+} ReleaseMode;
+
+typedef struct
+{
+    int version; // 1 (RB3)
+    float sustain_level;
+    float release_rate;
+    float sustain_rate;
+    float decay_rate;
+    float attack_rate;
+    ReleaseMode release_mode;
+    SustainMode sustain_mode;
+    AttackMode attack_mode;
+} ADSR;
+
+typedef enum <int>
+{
+    kFXCoreNone = -1,
+    kFXCore0 = 0,
+    kFXCore1 = 1
+} FXCore;
+
+// SfxMap version is the same as parent Sfx version, so we need to pass it through
+typedef struct(int version)
+{
+    NumString sample_name;
+    if(2 < version)
+    {
+        float volume;
+        float pan;
+        float transpose;
+        FXCore fx;
+        if(3 < version)
+        {
+            ADSR adsr;
+        }
+    }
+} SfxMap;
+
+typedef struct
+{
+    int version; // 0 is only version that seems to exist
+    
+    int faders_count;
+    NumString faders[faders_count]<optimize=false>;
+} FaderGroup;
+
+typedef struct (SystemInfo& info, Bool super)
+{
+    int version; // 9 (RB2/TBRB/GDRB), 12 (RB3)
+
+    if(version < 6)
+    {
+        if(1 < version)
+        {
+            read_metadata(info, super);
+        }
+    }
+    else
+    {
+        Sequence sequence(info, super);
+    }
+
+    int sfxmap_count;
+    SfxMap sfx_maps(version)[sfxmap_count]<optimize=false>;
+
+    if(9 < version)
+    {
+        int mogg_clip_count;
+        NumString mogg_clips[mogg_clip_count]<optimize=false>;
+    }
+
+    if(4 < version)
+    {
+        NumString send_obj;
+    }
+
+    if(8 < version)
+    {
+        FaderGroup fader_group;
+    }
+
+    if(version > 0xb)
+    {
+        float unk;
+        Bool unk_bool;
+    }
+
+
+} Sfx;
+
+#ifdef STANDALONE_FILE
+
+if (STANDALONE_FILE == "Sfx")
+{
+    local int obj_version = guess_version();
+    local SystemInfo info;
+    info.version = 25;
+
+    if (IsBigEndian())
+    {
+        info.platform = X360;
+    }
+    else
+    {
+        info.platform = PS2;
+    }
+
+    Sfx sfx(info, False);
+}
+
+#endif
+
+#endif

--- a/templates/milo/ui_label_dir.bt
+++ b/templates/milo/ui_label_dir.bt
@@ -1,0 +1,134 @@
+// Top-level resource object for UILabels
+// Super: RndDir
+// Ext: (None)
+// C++ Class: UILabelDir
+
+#ifndef IN_MILO_FILE
+    #ifndef STANDALONE_FILE
+        #define STANDALONE_FILE "UILabelDir"
+    #endif
+#endif
+
+#ifndef UI_LABEL_DIR
+#define UI_LABEL_DIR
+
+#include "common.bt"
+#include "rnd_dir.bt"
+
+typedef struct
+{
+    int version; // 9 (RB3)
+
+    Bool include_lower_case;
+    Bool include_upper_case;
+    Bool include_numbers;
+    Bool include_punctuation;
+    Bool include_upper_euro;
+    Bool include_lower_euro;
+    NumString plus_chars;
+    NumString minus_chars;
+    NumString font_name;
+
+    float font_pct_size;
+    int font_weight;
+    
+    Bool is_font_italic;
+
+    int pitch_and_family;
+
+    int font_quality;
+
+    int font_char_set;
+    int font_supersample;
+
+    NumString bitmap_path;
+    NumString bitmap_filename;
+
+    int tex_pad_left;
+    int tex_pad_right;
+    int tex_pad_top;
+    int tex_pad_bottom;
+
+    Bool fill_with_safe_white;
+
+    int gened_fonts_count;
+    NumString gen_fonts[gened_fonts_count] <optimize=false>;
+
+    NumString kerning_reference;
+
+    int mat_variations_count;
+    NumString mat_variations[mat_variations_count] <optimize=false>;
+
+    NumString default_mat;
+
+    NumString handmade_font;
+
+    NumString sync_resource;
+
+    Bool last_gen_was_ng;
+} UIFontImporter;
+
+typedef struct (SystemInfo& info, Bool super, Bool inlined)
+{
+    int version; // 3 (TBRB), 9 (RB3)
+    RndDir rnd_dir(info, False, inlined);
+
+    NumString text_object;
+
+    if(version == 3)
+    {
+        NumString font_ref;
+    }
+
+    NumString focus_anim;
+    NumString pulse_anim;
+
+    if(version == 9)
+    {
+
+        NumString highlight_mesh_group;
+
+        NumString top_left_highlight_bone;
+        NumString top_right_highlight_bone;
+        NumString bottom_left_highlight_bone;
+        NumString bottom_right_highlight_bone;
+
+        NumString focused_background_group;
+        NumString unfocused_background_group;
+
+        Bool allow_edit_text;
+    }
+    
+    NumString default_color;
+    NumString colors[5] <optimize=false>;
+
+    if(version == 9)
+    {
+        UIFontImporter font_importer;
+    }
+} UILabelDir;
+
+#ifdef STANDALONE_FILE
+
+if (STANDALONE_FILE == "UILabelDir")
+{
+    local int obj_version = guess_version();
+    local SystemInfo info;
+    info.version = 25;
+
+    if (IsBigEndian())
+    {
+        info.platform = X360;
+    }
+    else
+    {
+        info.platform = PS2;
+        info.version = 24;
+    }
+
+    UILabelDir label_dir(info, False, False);
+}
+
+#endif
+
+#endif


### PR DESCRIPTION
I have created templates for the following objects:
* ParticleSys
* Sfx
* RandomGroupSeq
* UILabelDir

These have well-tested support for GH2 360<-->RB3/DC1. Anything newer or older probably won't work (but might, since I tried to copy the version checks as closely as I could).

Please let me know if you see any issues here and I can fix or adjust these templates. Thanks.